### PR TITLE
Add address generation in I²C write

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,16 +280,19 @@ int8_t user_i2c_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, uint1
 
     /*
      * Data on the bus should be like
-     * |------------+---------------------|
-     * | I2C action | Data                |
-     * |------------+---------------------|
-     * | Start      | -                   |
-     * | Write      | (reg_addr)          |
-     * | Write      | (reg_data[0])       |
-     * | Write      | (....)              |
-     * | Write      | (reg_data[len - 1]) |
-     * | Stop       | -                   |
-     * |------------+---------------------|
+     * |------------+----------------------|
+     * | I2C action | Data                 |
+     * |------------+----------------------|
+     * | Start      | -                    |
+     * | Write      | (reg_addr)           |
+     * | Write      | (reg_data[0])        |
+     * | Write      | (reg_addr + 1)       |
+     * | Write      | (reg_data[1])        |
+     * | Write      | (....)               |
+     * | Write      | (reg_addr + len - 1) |
+     * | Write      | (reg_data[len - 1])  |
+     * | Stop       | -                    |
+     * |------------+----------------------|
      */
 
     return rslt;


### PR DESCRIPTION
According to the datasheet "6.2.1 I²C write" (and to my user C code), the address of each register has to be specified.