### PR TITLE
linux example improvements

### DIFF
--- a/examples/linux_userspace.c
+++ b/examples/linux_userspace.c
@@ -45,11 +45,23 @@ int8_t user_i2c_write(uint8_t id, uint8_t reg_addr, uint8_t *data, uint16_t len)
 
 void print_sensor_data(struct bme280_data *comp_data)
 {
+	float temp, press, hum;
 #ifdef BME280_FLOAT_ENABLE
-	printf("temp %0.2f, p %0.2f, hum %0.2f\n", comp_data->temperature, comp_data->pressure, comp_data->humidity);
+	temp = comp_data->temperature;
+	press = 0.01 * comp_data->pressure;
+	hum = comp_data->humidity;
 #else
-	printf("temp %d, p %d, hum %d\n", comp_data->temperature, comp_data->pressure, comp_data->humidity);
+#ifdef BME280_64BIT_ENABLE
+	temp = 0.01f * comp_data->temperature;
+	press = 0.0001f * comp_data->pressure;
+	hum = 1.0f / 1024.0f * comp_data->humidity;
+#else
+	temp = 0.01f * comp_data->temperature;
+	press = 0.01f * comp_data->pressure;
+	hum = 1.0f / 1024.0f * comp_data->humidity;
 #endif
+#endif
+	printf("%0.2lf deg C, %0.2lf hPa, %0.2lf%%\n", temp, press, hum);
 }
 
 int8_t stream_sensor_data_forced_mode(struct bme280_dev *dev)

--- a/examples/linux_userspace.c
+++ b/examples/linux_userspace.c
@@ -1,8 +1,8 @@
 /*
-  Linux userspace test code, simple and mose code directy from the doco.
-  compile like this: gcc linux_userspace.c ../bme280.c -I ../ -o bme280
-  tested: Raspberry Pi.
-  Use like: ./bme280 /dev/i2c-0
+	Linux userspace test code, simple and mose code directy from the doco.
+	compile like this: gcc linux_userspace.c ../bme280.c -I ../ -o bme280
+	tested: Raspberry Pi.
+	Use like: ./bme280 /dev/i2c-0
 */
 #include "bme280.h"
 #include <string.h>
@@ -18,115 +18,122 @@ int fd;
 
 int8_t user_i2c_read(uint8_t id, uint8_t reg_addr, uint8_t *data, uint16_t len)
 {
-  write(fd, &reg_addr,1);
-  read(fd, data, len);
-  return 0;
+	write(fd, &reg_addr, 1);
+	read(fd, data, len);
+	return 0;
 }
 
 void user_delay_ms(uint32_t period)
 {
-  usleep(period*1000);
+	usleep(period * 1000);
 }
 
 int8_t user_i2c_write(uint8_t id, uint8_t reg_addr, uint8_t *data, uint16_t len)
 {
-  int8_t *buf;
-  buf = malloc(len +1);
-  buf[0] = reg_addr;
-  memcpy(buf +1, data, len);
-  write(fd, buf, len +1);
-  free(buf);
-  return 0;
+	int8_t *buf;
+	buf = malloc(len +1);
+	buf[0] = reg_addr;
+	memcpy(buf + 1, data, len);
+	write(fd, buf, len + 1);
+	free(buf);
+	return 0;
 }
 
 void print_sensor_data(struct bme280_data *comp_data)
 {
 #ifdef BME280_FLOAT_ENABLE
-  printf("temp %0.2f, p %0.2f, hum %0.2f\r\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
+	printf("temp %0.2f, p %0.2f, hum %0.2f\n", comp_data->temperature, comp_data->pressure, comp_data->humidity);
 #else
-  printf("temp %ld, p %ld, hum %ld\r\n",comp_data->temperature, comp_data->pressure, comp_data->humidity);
+	printf("temp %d, p %d, hum %d\n", comp_data->temperature, comp_data->pressure, comp_data->humidity);
 #endif
 }
 
 int8_t stream_sensor_data_forced_mode(struct bme280_dev *dev)
 {
-  int8_t rslt;
-  uint8_t settings_sel;
-  struct bme280_data comp_data;
+	int8_t rslt;
+	uint8_t settings_sel;
+	struct bme280_data comp_data;
 
-  /* Recommended mode of operation: Indoor navigation */
-  dev->settings.osr_h = BME280_OVERSAMPLING_1X;
-  dev->settings.osr_p = BME280_OVERSAMPLING_16X;
-  dev->settings.osr_t = BME280_OVERSAMPLING_2X;
-  dev->settings.filter = BME280_FILTER_COEFF_16;
+	/* Recommended mode of operation: Indoor navigation */
+	dev->settings.osr_h = BME280_OVERSAMPLING_1X;
+	dev->settings.osr_p = BME280_OVERSAMPLING_16X;
+	dev->settings.osr_t = BME280_OVERSAMPLING_2X;
+	dev->settings.filter = BME280_FILTER_COEFF_16;
 
-  settings_sel = BME280_OSR_PRESS_SEL | BME280_OSR_TEMP_SEL | BME280_OSR_HUM_SEL | BME280_FILTER_SEL;
+	settings_sel = BME280_OSR_PRESS_SEL | BME280_OSR_TEMP_SEL | BME280_OSR_HUM_SEL | BME280_FILTER_SEL;
 
-  rslt = bme280_set_sensor_settings(settings_sel, dev);
+	rslt = bme280_set_sensor_settings(settings_sel, dev);
+	if (rslt != BME280_OK)
+	{
+		fprintf(stderr, "Failed to set sensor settings.");
+		return rslt;
+	}
 
-  printf("Temperature, Pressure, Humidity\r\n");
-  /* Continuously stream sensor data */
-  while (1)
-  {
-    rslt = bme280_set_sensor_mode(BME280_FORCED_MODE, dev);
-    if (rslt != BME280_OK)
-      break;
-    /* Wait for the measurement to complete and print data @25Hz */
-    dev->delay_ms(40);
-    rslt = bme280_get_sensor_data(BME280_ALL, &comp_data, dev);
-    if (rslt != BME280_OK)
-      break;
-    print_sensor_data(&comp_data);
-  }
-  return rslt;
+	printf("Temperature, Pressure, Humidity\n");
+	/* Continuously stream sensor data */
+	while (1)
+	{
+		rslt = bme280_set_sensor_mode(BME280_FORCED_MODE, dev);
+		if (rslt != BME280_OK)
+			break;
+		/* Wait for the measurement to complete and print data @25Hz */
+		dev->delay_ms(40);
+		rslt = bme280_get_sensor_data(BME280_ALL, &comp_data, dev);
+		if (rslt != BME280_OK)
+			break;
+		print_sensor_data(&comp_data);
+	}
+	return rslt;
 }
 
 int main(int argc, char* argv[])
 {
-  struct bme280_dev dev;
-  int8_t rslt = BME280_OK;
+	struct bme280_dev dev;
+	int8_t rslt = BME280_OK;
 
-  if (argc < 2)
-  {
-    printf("Missing argument for I2C device.\n");
-    exit(1);
-  }
-  
-  // make sure to select BME280_I2C_ADDR_PRIM
-  // or BME280_I2C_ADDR_SEC as needed
-  dev.dev_id =
+	if (argc < 2)
+	{
+		fprintf(stderr, "Missing argument for i2c bus.\n");
+		exit(1);
+	}
+	
+	// make sure to select BME280_I2C_ADDR_PRIM
+	// or BME280_I2C_ADDR_SEC as needed
+	dev.dev_id =
 #if 1
-    BME280_I2C_ADDR_PRIM
+		BME280_I2C_ADDR_PRIM
 #else
-    BME280_I2C_ADDR_SEC
+		BME280_I2C_ADDR_SEC
 #endif
-    ;
+		;
 
-  dev.intf = BME280_I2C_INTF;
-  dev.read = user_i2c_read;
-  dev.write = user_i2c_write;
-  dev.delay_ms = user_delay_ms;
+	dev.intf = BME280_I2C_INTF;
+	dev.read = user_i2c_read;
+	dev.write = user_i2c_write;
+	dev.delay_ms = user_delay_ms;
 
-  if ((fd = open(argv[1], O_RDWR)) < 0) {
-    printf("Failed to open the i2c bus %s\n", argv[1]);
-    exit(1);
-  }
-  if (ioctl(fd, I2C_SLAVE, dev.dev_id) < 0) {
-    printf("Failed to acquire bus access and/or talk to slave.\n");
-    exit(1);
-  }
-  
-  rslt = bme280_init(&dev);
-  if (rslt != BME280_OK)
-  {
-    printf("Failed to initialize the device.\n");
-    exit(1);
-  }
-  rslt = stream_sensor_data_forced_mode(&dev);
-  if (rslt != BME280_OK)
-  {
-    printf("Failed to stream sensor data.\n");
-    exit(1);
-  }
-  return 0;
+	if ((fd = open(argv[1], O_RDWR)) < 0)
+	{
+		fprintf(stderr, "Failed to open the i2c bus %s\n", argv[1]);
+		exit(1);
+	}
+	if (ioctl(fd, I2C_SLAVE, dev.dev_id) < 0)
+	{
+		fprintf(stderr, "Failed to acquire bus access and/or talk to slave.\n");
+		exit(1);
+	}
+	
+	rslt = bme280_init(&dev);
+	if (rslt != BME280_OK)
+	{
+		fprintf(stderr, "Failed to initialize the device.\n");
+		exit(1);
+	}
+	rslt = stream_sensor_data_forced_mode(&dev);
+	if (rslt != BME280_OK)
+	{
+		fprintf(stderr, "Failed to stream sensor data.\n");
+		exit(1);
+	}
+	return 0;
 }


### PR DESCRIPTION
I interfaced my first BME280 this week and two changes to the example would have saved me some hassle:
1. There are two possible chip ids (`[...]_PRIM` -> `0x76`, `[...]_SEC` -> `0x77`). `0x76` was hardcoded in the `ioctl()` call. This was causing a conflict when changing to the secondary chip id during `bme280_init()`. Replaced with existing defines from *bme280_def.h*.
2. No error handling was implemented. Especially for setting up i2c the first time a proper example would be very valuable. Return codes should not be ignored/hidden. Fixed.

The rest is cosmetics and human readable output of the sensor data in typical units.