### PR TITLE
Wait for data to copy before reading calibration data

### DIFF
--- a/bme280.c
+++ b/bme280.c
@@ -361,6 +361,7 @@ int8_t bme280_init(struct bme280_dev *dev)
     /* chip id read try count */
     uint8_t try_count = 5;
     uint8_t chip_id = 0;
+    uint8_t stat_reg = 0;
 
     /* Check for null pointer in the device structure*/
     rslt = null_ptr_check(dev);
@@ -382,6 +383,11 @@ int8_t bme280_init(struct bme280_dev *dev)
                 rslt = bme280_soft_reset(dev);
                 if (rslt == BME280_OK)
                 {
+                    /* Wait for data to be copied from NVM to registers */
+                    while (bme280_get_regs(BME280_STAT_ADDR, &stat_reg, 1, dev)
+                        != BME280_OK || (stat_reg & 1) != 0)
+                      dev->delay_ms(10);
+
                     /* Read the calibration data */
                     rslt = get_calib_data(dev);
                 }

--- a/bme280_defs.h
+++ b/bme280_defs.h
@@ -135,6 +135,7 @@
 #define BME280_HUMIDITY_CALIB_DATA_ADDR   UINT8_C(0xE1)
 #define BME280_PWR_CTRL_ADDR              UINT8_C(0xF4)
 #define BME280_CTRL_HUM_ADDR              UINT8_C(0xF2)
+#define BME280_STAT_ADDR                  UINT8_C(0xF3)
 #define BME280_CTRL_MEAS_ADDR             UINT8_C(0xF4)
 #define BME280_CONFIG_ADDR                UINT8_C(0xF5)
 #define BME280_DATA_ADDR                  UINT8_C(0xF7)


### PR DESCRIPTION
Working with ESP32, I was finding that the calibration data was being read from registers before the data was fully copied there from NVM. This resulted in the first several registers being 0 and yielding incorrect values.