### PR TITLE
Fix humidity uncompensated data based on data sheet memory map

### DIFF
--- a/bme280.c
+++ b/bme280.c
@@ -716,8 +716,8 @@ void bme280_parse_sensor_data(const uint8_t *reg_data, struct bme280_uncomp_data
     uncomp_data->temperature = data_msb | data_lsb | data_xlsb;
 
     /* Store the parsed register values for temperature data */
-    data_lsb = (uint32_t)reg_data[6] << 8;
-    data_msb = (uint32_t)reg_data[7];
+    data_msb = (uint32_t)reg_data[6] << 8;
+    data_lsb = (uint32_t)reg_data[7];
     uncomp_data->humidity = data_msb | data_lsb;
 }
 


### PR DESCRIPTION
Based on the [BoschSensortec BME280 data sheet](https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280-DS002.pdf), on page 27, table 18 shows the memory map. The humidity msb is in address 0xFD and the lsb is in 0xFE.  Below is a map of the addresses and how they map to the reg_data array.  The driver code reversed the msb and lsb.

| reg_data index |    0     |    1     |    2     |   3      |   4      |   5      |   6      |   7      |
|:--|:--|:--|:--|:--|:--|:--|:--|:--|
| address|    F7    |    F8    |    F9    |   FA     |   FB     |   FC     |   FD     |   FE     |
| measure | pressure | pressure | pressure |  temp    |  temp    |  temp    | humidity | humidity |
| |   msb    |   lsb    |   xlsb   |   msb    |   lsb    |   xlsb   |   msb    |   lsb    |
| bits | 76543210 | 76543210 | 7654xxxx | 76543210 | 76543210 | 7654xxxx | 76543210 | 76543210 |

![image](https://user-images.githubusercontent.com/1844480/68998323-9f90af80-0865-11ea-8cc6-48f5ee32a3b1.png)

