### PR TITLE
Add public API to parse calibration data

### DIFF
--- a/bme280.c
+++ b/bme280.c
@@ -729,6 +729,49 @@ void bme280_parse_sensor_data(const uint8_t *reg_data, struct bme280_uncomp_data
 }
 
 /*!
+ *  @brief This API is used to parse the pressure and temperature
+ *  calibration data and store it in the bme280_calib_data structure instance.
+ */
+void bme280_parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data)
+{
+    calib_data->dig_t1 = BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
+    calib_data->dig_t2 = (int16_t)BME280_CONCAT_BYTES(reg_data[3], reg_data[2]);
+    calib_data->dig_t3 = (int16_t)BME280_CONCAT_BYTES(reg_data[5], reg_data[4]);
+    calib_data->dig_p1 = BME280_CONCAT_BYTES(reg_data[7], reg_data[6]);
+    calib_data->dig_p2 = (int16_t)BME280_CONCAT_BYTES(reg_data[9], reg_data[8]);
+    calib_data->dig_p3 = (int16_t)BME280_CONCAT_BYTES(reg_data[11], reg_data[10]);
+    calib_data->dig_p4 = (int16_t)BME280_CONCAT_BYTES(reg_data[13], reg_data[12]);
+    calib_data->dig_p5 = (int16_t)BME280_CONCAT_BYTES(reg_data[15], reg_data[14]);
+    calib_data->dig_p6 = (int16_t)BME280_CONCAT_BYTES(reg_data[17], reg_data[16]);
+    calib_data->dig_p7 = (int16_t)BME280_CONCAT_BYTES(reg_data[19], reg_data[18]);
+    calib_data->dig_p8 = (int16_t)BME280_CONCAT_BYTES(reg_data[21], reg_data[20]);
+    calib_data->dig_p9 = (int16_t)BME280_CONCAT_BYTES(reg_data[23], reg_data[22]);
+    calib_data->dig_h1 = reg_data[25];
+}
+
+/*!
+ *  @brief This API is used to parse the humidity
+ *  calibration data and store it in the bme280_calib_data structure instance.
+ */
+void bme280_parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data)
+{
+    int16_t dig_h4_lsb;
+    int16_t dig_h4_msb;
+    int16_t dig_h5_lsb;
+    int16_t dig_h5_msb;
+
+    calib_data->dig_h2 = (int16_t)BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
+    calib_data->dig_h3 = reg_data[2];
+    dig_h4_msb = (int16_t)(int8_t)reg_data[3] * 16;
+    dig_h4_lsb = (int16_t)(reg_data[4] & 0x0F);
+    calib_data->dig_h4 = dig_h4_msb | dig_h4_lsb;
+    dig_h5_msb = (int16_t)(int8_t)reg_data[5] * 16;
+    dig_h5_lsb = (int16_t)(reg_data[4] >> 4);
+    calib_data->dig_h5 = dig_h5_msb | dig_h5_lsb;
+    calib_data->dig_h6 = (int8_t)reg_data[6];
+}
+
+/*!
  * @brief This API is used to compensate the pressure and/or
  * temperature and/or humidity data according to the component selected
  * by the user.
@@ -1403,41 +1446,6 @@ static void interleave_reg_addr(const uint8_t *reg_addr, uint8_t *temp_buff, con
         temp_buff[(index * 2) - 1] = reg_addr[index];
         temp_buff[index * 2] = reg_data[index];
     }
-}
-
-void bme280_parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data)
-{
-    calib_data->dig_t1 = BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
-    calib_data->dig_t2 = (int16_t)BME280_CONCAT_BYTES(reg_data[3], reg_data[2]);
-    calib_data->dig_t3 = (int16_t)BME280_CONCAT_BYTES(reg_data[5], reg_data[4]);
-    calib_data->dig_p1 = BME280_CONCAT_BYTES(reg_data[7], reg_data[6]);
-    calib_data->dig_p2 = (int16_t)BME280_CONCAT_BYTES(reg_data[9], reg_data[8]);
-    calib_data->dig_p3 = (int16_t)BME280_CONCAT_BYTES(reg_data[11], reg_data[10]);
-    calib_data->dig_p4 = (int16_t)BME280_CONCAT_BYTES(reg_data[13], reg_data[12]);
-    calib_data->dig_p5 = (int16_t)BME280_CONCAT_BYTES(reg_data[15], reg_data[14]);
-    calib_data->dig_p6 = (int16_t)BME280_CONCAT_BYTES(reg_data[17], reg_data[16]);
-    calib_data->dig_p7 = (int16_t)BME280_CONCAT_BYTES(reg_data[19], reg_data[18]);
-    calib_data->dig_p8 = (int16_t)BME280_CONCAT_BYTES(reg_data[21], reg_data[20]);
-    calib_data->dig_p9 = (int16_t)BME280_CONCAT_BYTES(reg_data[23], reg_data[22]);
-    calib_data->dig_h1 = reg_data[25];
-}
-
-void bme280_parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data)
-{
-    int16_t dig_h4_lsb;
-    int16_t dig_h4_msb;
-    int16_t dig_h5_lsb;
-    int16_t dig_h5_msb;
-
-    calib_data->dig_h2 = (int16_t)BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
-    calib_data->dig_h3 = reg_data[2];
-    dig_h4_msb = (int16_t)(int8_t)reg_data[3] * 16;
-    dig_h4_lsb = (int16_t)(reg_data[4] & 0x0F);
-    calib_data->dig_h4 = dig_h4_msb | dig_h4_lsb;
-    dig_h5_msb = (int16_t)(int8_t)reg_data[5] * 16;
-    dig_h5_lsb = (int16_t)(reg_data[4] >> 4);
-    calib_data->dig_h5 = dig_h5_msb | dig_h5_lsb;
-    calib_data->dig_h6 = (int8_t)reg_data[6];
 }
 
 /*!

--- a/bme280.c
+++ b/bme280.c
@@ -1405,14 +1405,8 @@ static void interleave_reg_addr(const uint8_t *reg_addr, uint8_t *temp_buff, con
     }
 }
 
-/*!
- *  @brief This internal API is used to parse the temperature and
- *  pressure calibration data and store it in device structure.
- */
-static void parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_dev *dev)
+void bme280_parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data)
 {
-    struct bme280_calib_data *calib_data = &dev->calib_data;
-
     calib_data->dig_t1 = BME280_CONCAT_BYTES(reg_data[1], reg_data[0]);
     calib_data->dig_t2 = (int16_t)BME280_CONCAT_BYTES(reg_data[3], reg_data[2]);
     calib_data->dig_t3 = (int16_t)BME280_CONCAT_BYTES(reg_data[5], reg_data[4]);
@@ -1428,13 +1422,8 @@ static void parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_d
     calib_data->dig_h1 = reg_data[25];
 }
 
-/*!
- *  @brief This internal API is used to parse the humidity calibration data
- *  and store it in device structure.
- */
-static void parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_dev *dev)
+void bme280_parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data)
 {
-    struct bme280_calib_data *calib_data = &dev->calib_data;
     int16_t dig_h4_lsb;
     int16_t dig_h4_msb;
     int16_t dig_h5_lsb;
@@ -1449,6 +1438,26 @@ static void parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_dev
     dig_h5_lsb = (int16_t)(reg_data[4] >> 4);
     calib_data->dig_h5 = dig_h5_msb | dig_h5_lsb;
     calib_data->dig_h6 = (int8_t)reg_data[6];
+}
+
+/*!
+ *  @brief This internal API is used to parse the temperature and
+ *  pressure calibration data and store it in device structure.
+ */
+static void parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_dev *dev)
+{
+    struct bme280_calib_data *calib_data = &dev->calib_data;
+    bme280_parse_temp_press_calib_data(reg_data, calib_data);
+}
+
+/*!
+ *  @brief This internal API is used to parse the humidity calibration data
+ *  and store it in device structure.
+ */
+static void parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_dev *dev)
+{
+    struct bme280_calib_data *calib_data = &dev->calib_data;
+    bme280_parse_humidity_calib_data(reg_data, calib_data);
 }
 
 /*!

--- a/bme280.h
+++ b/bme280.h
@@ -206,6 +206,10 @@ int8_t bme280_get_sensor_data(uint8_t sensor_comp, struct bme280_data *comp_data
  */
 void bme280_parse_sensor_data(const uint8_t *reg_data, struct bme280_uncomp_data *uncomp_data);
 
+void bme280_parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data);
+
+void bme280_parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data);
+
 /*!
  * @brief This API is used to compensate the pressure and/or
  * temperature and/or humidity data according to the component selected by the

--- a/bme280.h
+++ b/bme280.h
@@ -206,8 +206,22 @@ int8_t bme280_get_sensor_data(uint8_t sensor_comp, struct bme280_data *comp_data
  */
 void bme280_parse_sensor_data(const uint8_t *reg_data, struct bme280_uncomp_data *uncomp_data);
 
+/*!
+ *  @brief This API is used to parse the pressure and temperature 
+ *  calibration data and store it in the bme280_calib_data structure instance.
+ *
+ *  @param[in] reg_data     : Contains register data which needs to be parsed
+ *  @param[out] calib_data  : Contains the calibration data.
+ */
 void bme280_parse_temp_press_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data);
 
+/*!
+ *  @brief This API is used to parse the humidity
+ *  calibration data and store it in the bme280_calib_data structure instance.
+ *
+ *  @param[in] reg_data     : Contains register data which needs to be parsed
+ *  @param[out] uncomp_data : Contains the calibration data.
+ */
 void bme280_parse_humidity_calib_data(const uint8_t *reg_data, struct bme280_calib_data *calib_data);
 
 /*!


### PR DESCRIPTION
`bme280_parse_temp_press_calib_data` and `bme280_parse_humidity_calib_data` functions are extracted from internal API to accompany existing `bme280_parse_sensor_data` and `bme280_compensate_data` in order to allow processing data gathered outside the driver.

This is useful for applications which do not find API based on `struct bme280_dev` suitable and would rather communicate with the sensor on their own.