### PR TITLE
fixed example to work on a raspberry pi

### DIFF
--- a/examples/linux_userspace.c
+++ b/examples/linux_userspace.c
@@ -15,10 +15,8 @@
  * \include linux_userspace.c
  */
 
-#ifdef __KERNEL__
 #include <linux/i2c-dev.h>
 #include <sys/ioctl.h>
-#endif
 
 /******************************************************************************/
 /*!                         System header files                               */
@@ -143,13 +141,11 @@ int main(int argc, char* argv[])
         exit(1);
     }
 
-#ifdef __KERNEL__
     if (ioctl(fd, I2C_SLAVE, dev.dev_id) < 0)
     {
         fprintf(stderr, "Failed to acquire bus access and/or talk to slave.\n");
         exit(1);
     }
-#endif
 
     /* Initialize the bme280 */
     rslt = bme280_init(&dev);


### PR DESCRIPTION
the linux api to talk to i2c devices requires that the device id be specified by ioctl, otherwise how would it know which device to talk to?!