### PR TITLE
Fix problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dev.intf_ptr = &dev_addr;
 dev.intf = BME280_SPI_INTF;
 dev.read = user_spi_read;
 dev.write = user_spi_write;
-dev.delay_ms = user_delay_ms;
+dev.delay_us = user_delay_ms;
 
 rslt = bme280_init(&dev);
 ```
@@ -54,7 +54,7 @@ dev.intf_ptr = &dev_addr;
 dev.intf = BME280_I2C_INTF;
 dev.read = user_i2c_read;
 dev.write = user_i2c_write;
-dev.delay_ms = user_delay_ms;
+dev.delay_us = user_delay_ms;
 
 rslt = bme280_init(&dev);
 ```
@@ -122,7 +122,7 @@ int8_t stream_sensor_data_forced_mode(struct bme280_dev *dev)
     while (1) {
         rslt = bme280_set_sensor_mode(BME280_FORCED_MODE, dev);
         /* Wait for the measurement to complete and print data @25Hz */
-        dev->delay_ms(req_delay, dev->intf_ptr);
+        dev->delay_us(req_delay, dev->intf_ptr);
         rslt = bme280_get_sensor_data(BME280_ALL, &comp_data, dev);
         print_sensor_data(&comp_data);
     }
@@ -164,7 +164,7 @@ int8_t stream_sensor_data_normal_mode(struct bme280_dev *dev)
 	printf("Temperature, Pressure, Humidity\r\n");
 	while (1) {
 		/* Delay while the sensor completes a measurement */
-		dev->delay_ms(70, dev->intf_ptr);
+		dev->delay_us(70, dev->intf_ptr);
 		rslt = bme280_get_sensor_data(BME280_ALL, &comp_data, dev);
 		print_sensor_data(&comp_data);
 	}

--- a/bme280_defs.h
+++ b/bme280_defs.h
@@ -286,7 +286,7 @@ typedef BME280_INTF_RET_TYPE (*bme280_read_fptr_t)(uint8_t reg_addr, uint8_t *re
  * @retval Non zero value -> Fail.
  *
  */
-typedef BME280_INTF_RET_TYPE (*bme280_write_fptr_t)(uint8_t reg_addr, const uint8_t *reg_data, uint32_t len,
+typedef BME280_INTF_RET_TYPE (*bme280_write_fptr_t)(uint8_t reg_addr, uint8_t *reg_data, uint32_t len,
                                                     void *intf_ptr);
 
 /*!


### PR DESCRIPTION
I was trying this driver in my esp8266 microcontroller and I've detect these errors, the readme documentation shows `delay_ms` is in the `bme280_dev` struct but is not, instead of `delay_ms` is `delay_us`. 

At the compilation time this error arrives me:
`error: invalid conversion from 'int8_t (*)(uint8_t, uint8_t*, uint32_t, void*)`
I've review the code and I've detect the `const` type of variable is in the `reg_data` pointer at `bme280_write_fptr_t` typedef for write method.

I hope this PR help us, thank you so much.