### PR TITLE
Update linux_userspace.c

### DIFF
--- a/examples/linux_userspace.c
+++ b/examples/linux_userspace.c
@@ -20,10 +20,10 @@
  * \include linux_userspace.c
  */
 
-#ifdef __KERNEL__
+//#ifdef __KERNEL__
 #include <linux/i2c-dev.h>
 #include <sys/ioctl.h>
-#endif
+//#endif
 
 /******************************************************************************/
 /*!                         System header files                               */
@@ -153,18 +153,19 @@ int main(int argc, char* argv[])
         fprintf(stderr, "Failed to open the i2c bus %s\n", argv[1]);
         exit(1);
     }
-
-#ifdef __KERNEL__
+    
+    id.dev_addr = BME280_I2C_ADDR_PRIM;
+//#ifdef __KERNEL__
     if (ioctl(id.fd, I2C_SLAVE, id.dev_addr) < 0)
     {
         fprintf(stderr, "Failed to acquire bus access and/or talk to slave.\n");
         exit(1);
     }
 
-#endif
+//#endif
 
     /* Make sure to select BME280_I2C_ADDR_PRIM or BME280_I2C_ADDR_SEC as needed */
-    id.dev_addr = BME280_I2C_ADDR_PRIM;
+
 
     dev.intf = BME280_I2C_INTF;
     dev.read = user_i2c_read;


### PR DESCRIPTION
How did you make this work?
Like this, ioctl is never started and device address is nowhere used. Besides that, setting dev_addr was done after ioctl call,
Consequently, it failed.
With the proposed changed it runs on my Raspberry Pi Zero. 

Nevertheless the proposed force mode code only returns static values. 
Could be fixed by using the normal mode with code as proposed in the project's documentation.

Error handling for user read would be fine, but ok, it's up to each user.
Still I have some doubts when I compare this to I2C read&write methods of WiringPi, which calls ioctl before each access.
Did not follow up here, but guess it's needed when you want to access different devices within a program.