### PR TITLE
Fix name of ifdef in linux_userspace.c

### DIFF
--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -246,7 +246,7 @@ void print_sensor_data(struct bme280_data *comp_data)
 {
     float temp, press, hum;
 
-#ifdef BME280_FLOAT_ENABLE
+#ifdef BME280_DOUBLE_ENABLE
     temp = comp_data->temperature;
     press = 0.01 * comp_data->pressure;
     hum = comp_data->humidity;


### PR DESCRIPTION
Previously linux_userspace.c had used BME280_FLOAT_ENABLE, but bme280.c defines BME280_DOUBLE_ENABLE.