### PR TITLE
Bugfix/report failed read

### DIFF
--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -200,9 +200,10 @@ int8_t user_i2c_read(uint8_t reg_addr, uint8_t *data, uint32_t len, void *intf_p
     struct identifier id;
 
     id = *((struct identifier *)intf_ptr);
-
     write(id.fd, &reg_addr, 1);
-    read(id.fd, data, len);
+    if (read(id.fd, data, len) != len) {
+        return -1;
+    }
 
     return 0;
 }

--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -246,7 +246,7 @@ void print_sensor_data(struct bme280_data *comp_data)
 {
     float temp, press, hum;
 
-#ifdef BME280_FLOAT_ENABLE
+#ifdef BME280_DOUBLE_ENABLE
     temp = comp_data->temperature;
     press = 0.01 * comp_data->pressure;
     hum = comp_data->humidity;


### PR DESCRIPTION
Builds on #89. Let me know if you want this as a fully independent PR.

Debugging issues with the I2C connection was a little more annoying than necessary since the example code failed later than it should have.

This pull request adds checking for whether a read succeeded, which in turn lets `bme280_init` fail with `BME280_E_COMM_FAIL`.