### PR TITLE
Cleanup/remove wiringpi dependency

### DIFF
--- a/examples/contributed/Makefile
+++ b/examples/contributed/Makefile
@@ -1,5 +1,5 @@
 raspbian: 
-	gcc linux_userspace.c ../../bme280.c -I ../.. -lwiringPi -o bme280
+	gcc linux_userspace.c ../../bme280.c -I ../.. -o bme280
 
 bsd:
 	gcc bsd_userspace.c ../../bme280.c -I ../.. -o bme280

--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -200,9 +200,10 @@ int8_t user_i2c_read(uint8_t reg_addr, uint8_t *data, uint32_t len, void *intf_p
     struct identifier id;
 
     id = *((struct identifier *)intf_ptr);
-
     write(id.fd, &reg_addr, 1);
-    read(id.fd, data, len);
+    if (read(id.fd, data, len) != len) {
+        return -1;
+    }
 
     return 0;
 }

--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -246,7 +246,7 @@ void print_sensor_data(struct bme280_data *comp_data)
 {
     float temp, press, hum;
 
-#ifdef BME280_FLOAT_ENABLE
+#ifdef BME280_DOUBLE_ENABLE
     temp = comp_data->temperature;
     press = 0.01 * comp_data->pressure;
     hum = comp_data->humidity;


### PR DESCRIPTION
This builds on #89 and #90. Please let me know if you'd like it as an independent PR.

I'm not sure why the Makefile was linking against it, since its headers aren't used.