### PR TITLE
Bugfix/always set address

### DIFF
--- a/examples/contributed/Makefile
+++ b/examples/contributed/Makefile
@@ -1,5 +1,5 @@
 raspbian: 
-	gcc linux_userspace.c ../../bme280.c -I ../.. -lwiringPi -o bme280
+	gcc linux_userspace.c ../../bme280.c -I ../.. -o bme280
 
 bsd:
 	gcc bsd_userspace.c ../../bme280.c -I ../.. -o bme280

--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -20,10 +20,8 @@
  * \include linux_userspace.c
  */
 
-#ifdef __KERNEL__
 #include <linux/i2c-dev.h>
 #include <sys/ioctl.h>
-#endif
 
 /******************************************************************************/
 /*!                         System header files                               */
@@ -154,17 +152,14 @@ int main(int argc, char* argv[])
         exit(1);
     }
 
-#ifdef __KERNEL__
+    /* Make sure to select BME280_I2C_ADDR_PRIM or BME280_I2C_ADDR_SEC as needed */
+    id.dev_addr = BME280_I2C_ADDR_PRIM;
+
     if (ioctl(id.fd, I2C_SLAVE, id.dev_addr) < 0)
     {
         fprintf(stderr, "Failed to acquire bus access and/or talk to slave.\n");
         exit(1);
     }
-
-#endif
-
-    /* Make sure to select BME280_I2C_ADDR_PRIM or BME280_I2C_ADDR_SEC as needed */
-    id.dev_addr = BME280_I2C_ADDR_PRIM;
 
     dev.intf = BME280_I2C_INTF;
     dev.read = user_i2c_read;

--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -200,9 +200,10 @@ int8_t user_i2c_read(uint8_t reg_addr, uint8_t *data, uint32_t len, void *intf_p
     struct identifier id;
 
     id = *((struct identifier *)intf_ptr);
-
     write(id.fd, &reg_addr, 1);
-    read(id.fd, data, len);
+    if (read(id.fd, data, len) != len) {
+        return -1;
+    }
 
     return 0;
 }

--- a/examples/contributed/linux_userspace.c
+++ b/examples/contributed/linux_userspace.c
@@ -246,7 +246,7 @@ void print_sensor_data(struct bme280_data *comp_data)
 {
     float temp, press, hum;
 
-#ifdef BME280_FLOAT_ENABLE
+#ifdef BME280_DOUBLE_ENABLE
     temp = comp_data->temperature;
     press = 0.01 * comp_data->pressure;
     hum = comp_data->humidity;


### PR DESCRIPTION
Builds on #89, #90, #91. Please let me know if you'd like these submitted differently!

The read/write calls do not have a way to specify the I2C device address. Instead, that is set by the ioctl call. 

I'm not sure why that part had been inside `#ifdef __KERNEL__` guards. When I tried defining __KERNEL__, I wound up with a ton of compiler errors, so I just deleted those guards and everything worked.

Relatedly, `id.dev_addr` needs to be set before being used.

I don't see how the code as-is would have ever worked, but I'm also not using a Raspberry Pi, so there could be differences there. (I'm testing on an ODroid C-4, using the /dev/i2c-0 bus to communicate with the BME280.)